### PR TITLE
Update loglogisticreg

### DIFF
--- a/R/LogLogisticRegression.R
+++ b/R/LogLogisticRegression.R
@@ -194,7 +194,7 @@ logLogisticRegression <- function(conc,
 
   guess <- CoreGx::.fitCurve(x = log_conc,
                               y = viability,
-                              f = .Hill,
+                              f = PharmacoGx:::.Hill,
                               density = density,
                               step = step,
                               precision = precision,

--- a/R/LogLogisticRegression.R
+++ b/R/LogLogisticRegression.R
@@ -60,7 +60,7 @@ logLogisticRegression <- function(conc,
                                   conc_as_log = FALSE,
                                   viability_as_pct = TRUE,
                                   trunc = TRUE,
-                                  verbose = FALSE) {
+                                  verbose = TRUE) {
   # guess <- .logLogisticRegressionRaw(conc, viability, density , step, precision, lower_bounds, upper_bounds, scale, Cauchy_flag, conc_as_log, viability_as_pct, trunc, verbose)
 
 
@@ -78,6 +78,7 @@ logLogisticRegression <- function(conc,
 #                                   trunc = TRUE,
 #                                   verbose = FALSE) {
   family <- match.arg(family)
+
 
   if (prod(is.finite(step)) != 1) {
     print(step)
@@ -149,16 +150,39 @@ logLogisticRegression <- function(conc,
     print(scale)
     stop("Scale parameter is a nonpositive number.")
   }
-  
-  cleanData  <- sanitizeInput(conc=conc,
-            viability=viability,
-            conc_as_log = conc_as_log,
-            viability_as_pct = viability_as_pct,
-            trunc = trunc,
-            verbose=verbose)
+ 
 
-  log_conc <- cleanData[["log_conc"]]
-  viability <- cleanData[["viability"]]
+
+
+
+  CoreGx::.sanitizeInput(x = conc,
+                         y = viability,
+                         x_as_log = conc_as_log,
+                         y_as_log = FALSE,
+                         y_as_pct = viability_as_pct,
+                         trunc = trunc,
+                         verbose = verbose)
+
+  cleanData <- CoreGx::.reformatData(x = conc,
+                               y = viability,
+                               x_to_log = !conc_as_log,
+                               y_to_log = FALSE,
+                               y_to_frac = viability_as_pct,
+                               trunc = trunc)
+
+  if (!(all(lower_bounds < upper_bounds))) {
+    if (verbose == 2) {
+      message("lower_bounds:")
+      message(lower_bounds)
+      message("upper_bounds:")
+      message(upper_bounds)
+    }
+    stop ("All lower bounds must be less than the corresponding upper_bounds.")
+  }
+
+
+  log_conc <- cleanData[["x"]]
+  viability <- cleanData[["y"]]
   
   
   #ATTEMPT TO REFINE GUESS WITH L-BFGS OPTIMIZATION
@@ -166,100 +190,25 @@ logLogisticRegression <- function(conc,
   gritty_guess <- c(pmin(pmax(1, lower_bounds[1]), upper_bounds[1]),
                     pmin(pmax(min(viability), lower_bounds[2]), upper_bounds[2]),
                     pmin(pmax(log_conc[which.min(abs(viability - 1/2))], lower_bounds[3]), upper_bounds[3]))
-  guess <- tryCatch(optim(par=gritty_guess,#par = sieve_guess,
-                          fn = function(x) {.residual(log_conc,
-                                                      viability,
-                                                      pars = x,
-                                                      n = median_n,
-                                                      scale = scale,
-                                                      family = family,
-                                                      trunc = trunc)
-                          },
-                          lower = lower_bounds,
-                          upper = upper_bounds,
-                          method = "L-BFGS-B",
-                          #control=list(maxit=100000)
-                          ),#[[1]],
-                    error = function(e) {
-                      list("par"=gritty_guess, "convergence"=-1)
-                    })
-  # if(guess[["convergence"]]!=0)  print(guess[["message"]]); #print(results[["convergence"]])
-  failed = guess[["convergence"]]!=0
-  guess <- guess[["par"]]
   
-  guess_residual <- .residual(log_conc,
-                              viability,
-                              pars = guess,
-                              n = median_n,
+
+  guess <- CoreGx::.fitCurve(x = log_conc,
+                              y = viability,
+                              f = .Hill,
+                              density = density,
+                              step = step,
+                              precision = precision,
+                              lower_bounds = lower_bounds,
+                              upper_bounds = upper_bounds,
                               scale = scale,
                               family = family,
-                              trunc = trunc)
-  
+                              median_n = median_n,
+                              trunc = trunc,
+                              verbose = verbose,
+                              gritty_guess = gritty_guess,
+                              span = 1)
 
-  #GENERATE INITIAL GUESS BY OBJECTIVE FUNCTION EVALUATION AT LATTICE POINTS
 
-  gritty_guess_residual <- .residual(log_conc,
-                                    viability,
-                                    pars = gritty_guess,
-                                    n = median_n,
-                                    scale = scale,
-                                    family = family,
-                                    trunc = trunc)
-  
-
-  #CHECK SUCCESS OF L-BFGS OPTIMIZAITON AND RE-OPTIMIZE WITH A PATTERN SEARCH IF NECESSARY
-  if (failed || any(is.na(guess)) || guess_residual >= gritty_guess_residual) {
-    #GENERATE INITIAL GUESS BY OBJECTIVE FUNCTION EVALUATION AT LATTICE POINTS
-    sieve_guess <- .meshEval(log_conc,
-                           viability,
-                           lower_bounds = lower_bounds,
-                           upper_bounds = upper_bounds,
-                           density = density,
-                           n=median_n,
-                           scale = scale,
-                           family = family,
-                           trunc = trunc)
-
-    sieve_guess_residual <- .residual(log_conc,
-                                    viability,
-                                    pars = sieve_guess,
-                                    n = median_n,
-                                    scale = scale,
-                                    family = family,
-                                    trunc = trunc)
-
-    guess <- sieve_guess
-    guess_residual <- sieve_guess_residual
-    span <- 1
-    
-    while (span > precision) {
-      neighbours <- rbind(guess, guess, guess, guess, guess, guess)
-      neighbour_residuals <- matrix(NA, nrow=1, ncol=6)
-      neighbours[1, 1] <- pmin(neighbours[1, 1] + span * step[1], upper_bounds[1])
-      neighbours[2, 1] <- pmax(neighbours[2, 1] - span * step[1], lower_bounds[1])
-      neighbours[3, 2] <- pmin(neighbours[3, 2] + span * step[2], upper_bounds[2])
-      neighbours[4, 2] <- pmax(neighbours[4, 2] - span * step[2], lower_bounds[2])
-      neighbours[5, 3] <- pmin(neighbours[5, 3] + span * step[3], upper_bounds[3])
-      neighbours[6, 3] <- pmax(neighbours[6, 3] - span * step[3], lower_bounds[3])
-      
-      for (i in seq_len(nrow(neighbours))) {
-        neighbour_residuals[i] <- .residual(log_conc,
-                                            viability,
-                                            pars = neighbours[i, ],
-                                            n = median_n,
-                                            scale = scale,
-                                            family = family,
-                                            trunc = trunc)
-      }
-      
-      if (min(neighbour_residuals) < guess_residual) {
-        guess <- neighbours[which.min(neighbour_residuals), ]
-        guess_residual <- min(neighbour_residuals)
-      } else {
-        span <- span / 2
-      }
-    }
-  }
 
   return(list("HS" = guess[1],
               "E_inf" = ifelse(viability_as_pct, 100 * guess[2], guess[2]),

--- a/R/LogLogisticRegression.R
+++ b/R/LogLogisticRegression.R
@@ -42,7 +42,11 @@
 #' @param trunc `logical`, if true, causes viability data to be truncated to lie between 0 and 1 before 
 #' curve-fitting is performed.
 #' @param verbose `logical`, if true, causes warnings thrown by the function to be printed.
-#' @return A vector containing estimates for HS, E_inf, and EC50
+#' @return A list containing estimates for HS, E_inf, and EC50. It is annotated with the attribute Rsquared, which is the R^2 of the fit. 
+#' Note that this is calculated using the values actually used for the fit, after truncation and any transform applied. With truncation, this will be 
+#' different from the R^2 compared to the variance of the raw data. This also means that if all points were truncated down or up, there is no variance 
+#' in the data, and the R^2 may be NaN. 
+#'
 #' @export
 #' 
 #' @importFrom CoreGx .meshEval .residual
@@ -208,9 +212,10 @@ logLogisticRegression <- function(conc,
                               gritty_guess = gritty_guess,
                               span = 1)
 
-
-
-  return(list("HS" = guess[1],
+  returnval <- list("HS" = guess[1],
               "E_inf" = ifelse(viability_as_pct, 100 * guess[2], guess[2]),
-              "EC50" = ifelse(conc_as_log, guess[3], 10 ^ guess[3])))
+              "EC50" = ifelse(conc_as_log, guess[3], 10 ^ guess[3]))
+  attr(returnval, "Rsquare") <- attr(guess, "Rsquare")
+
+  return(returnval)
 }

--- a/man/geneDrugSensitivity.Rd
+++ b/man/geneDrugSensitivity.Rd
@@ -36,7 +36,7 @@ set to FALSE}
 \item{verbose}{\code{boolean} Should the function display messages?}
 }
 \value{
-A \code{vector} reporting the effect size (estimateof the coefficient
+A \code{vector} reporting the effect size (estimate of the coefficient
 of drug concentration), standard error (se), sample size (n), t statistic,
 and F statistics and its corresponding p-value.
 }

--- a/man/logLogisticRegression.Rd
+++ b/man/logLogisticRegression.Rd
@@ -19,7 +19,7 @@ logLogisticRegression(
   conc_as_log = FALSE,
   viability_as_pct = TRUE,
   trunc = TRUE,
-  verbose = FALSE
+  verbose = TRUE
 )
 }
 \arguments{
@@ -68,7 +68,10 @@ curve-fitting is performed.}
 \item{verbose}{\code{logical}, if true, causes warnings thrown by the function to be printed.}
 }
 \value{
-A vector containing estimates for HS, E_inf, and EC50
+A list containing estimates for HS, E_inf, and EC50. It is annotated with the attribute Rsquared, which is the R^2 of the fit.
+Note that this is calculated using the values actually used for the fit, after truncation and any transform applied. With truncation, this will be
+different from the R^2 compared to the variance of the raw data. This also means that if all points were truncated down or up, there is no variance
+in the data, and the R^2 may be NaN.
 }
 \description{
 By default, logLogisticRegression uses an L-BFGS algorithm to generate the fit. However, if

--- a/tests/testthat/test_computeABC.R
+++ b/tests/testthat/test_computeABC.R
@@ -15,8 +15,8 @@ test_that("Function complains when given insensible input",{
 	# 	viability1 = c(50, 60, 70),
 	# 	Hill_fit2 = c(0.5, 0.2, 1)))
 
-	expect_error(computeABC(conc1 = c(1, 2),
-		conc2 = c(1, 2, 3),
+	expect_error(computeABC(conc1 = c(1, 2,3),
+		conc2 = c(1, 2, 3, 4),
 		viability1 = c(50, 60, 70),
 		viability2 = c(40, 90, 10)), "is not of same length") #should complain
 	expect_error(computeABC(conc1 = c(-1, 2, 3),
@@ -25,11 +25,11 @@ test_that("Function complains when given insensible input",{
 		viability2 = c(40, 90, 10),
 		conc_as_log = FALSE)) #should complain
 	##TO-DO::Add warning string to expect_warning call
-	expect_warning(expect_error(computeABC(conc1 = c(NA, "cat", 3),
+	expect_error(computeABC(conc1 = c(NA, "cat", 3),
 		conc2 = c(1, -2, 3),
 		viability1 = c(50, 60, 70),
 		viability2 = c(40, 90, 10),
-		conc_as_log = FALSE))) #should complain
+		conc_as_log = FALSE)) #should complain
 	expect_error(computeABC(conc1 = c(1, 2, 3),
 		conc2 = c(1, -2, 3),
 		viability1 = c(50, 60, 70),

--- a/tests/testthat/test_computeIC50.R
+++ b/tests/testthat/test_computeIC50.R
@@ -10,14 +10,14 @@ test_that("Function complains when given insensible input",{
 	# 		# 	viability1 = c(50, 60, 70),
 	# 	Hill_fit2 = c(0.5, 0.2, 1)))
 
-	expect_error(computeIC50(concentration = c(1, 2), viability = c(50, 60, 70)), "is not of same length") #should complain
-	expect_error(computeIC50(concentration = c(-1, 2, 3),viability = c(50, 60, 70),conc_as_log = FALSE),"Negative concentrations encountered") #should complain
+	expect_error(computeIC50(concentration = c(1, 2, 3, 5), viability = c(50, 60, 70)), "is not of same length") #should complain
+	expect_error(computeIC50(concentration = c(-1, 2, 3),viability = c(50, 60, 70),conc_as_log = FALSE),"'x_as_log' flag may be set incorrectly") #should complain
 	##TO-DO:: Add wanring strings to expect_warning call
-	expect_warning(expect_error(computeIC50(concentration = c(NA, "cat", 3), viability = c(50, 60, 70), conc_as_log = FALSE), "Concentration vector contains elements which are not real numbers.")) #should complain
-	expect_error(computeIC50(concentration = c(1, 2, Inf), viability = c(50, 60, 70)), "Concentration vector contains elements which are not real numbers.") #should complain
+	expect_error(computeIC50(concentration = c(NA, "cat", 3), viability = c(50, 60, 70), conc_as_log = FALSE), "real numbers") #should complain
+	expect_error(computeIC50(concentration = c(1, 2, Inf), viability = c(50, 60, 70)), "real numbers, NA-values, and/or -Inf") #should complain
 	expect_warning(computeIC50(concentration = c(1, 2, 3),
 		viability = c(.50, .60, .70),
-		viability_as_pct = TRUE), "viability_as_pct") #should complain
+		viability_as_pct = TRUE), "as_pct") #should complain
 	expect_error(computeIC50()) #should complain
 })
 

--- a/tests/testthat/test_logLogisticRegression.R
+++ b/tests/testthat/test_logLogisticRegression.R
@@ -7,10 +7,10 @@ context("Testing LogLogisticRegression.")
 test_that("Errors are checked.",{
 	
     expect_error(logLogisticRegression(c(1, 2, 3), c(50, 60))) #should complain
-    expect_warning(logLogisticRegression(c(1, 2, 3), c(50, 60, 70), viability_as_pct = FALSE)) #should complain
-    expect_error(logLogisticRegression(c(-1, 2, 3), c(50, 60, 70), conc_as_log = FALSE)) #should complain
-    ##TO-DO::Add warning string to expect_warning call
-    expect_warning(expect_error(logLogisticRegression(c(1, 2, 3), c(50, 60, 70), median_n = 0))) #should complain
+    expect_warning(logLogisticRegression(c(1, 2, 3), c(70, 60, 50), viability_as_pct = FALSE)) #should complain
+    expect_error(logLogisticRegression(c(-1, 2, 3), c(70, 60, 50), conc_as_log = FALSE)) #should complain
+
+    expect_error(logLogisticRegression(c(1, 2, 3), c(70, 60, 50), median_n = 0)) #should complain
     expect_error(logLogisticRegression(c(1, 2, 3), c(50, 60, 70), median_n = 3/2)) #should complain
     expect_error(logLogisticRegression(c(1, 2, 3), c(50, 60, 70), density = c(1, 1))) #should complain
     expect_error(logLogisticRegression(c(1, 2, 3), c(50, 60, 70), density = c(1, 1, -1))) #should complain
@@ -25,11 +25,37 @@ test_that("Values returned as expected (previous runs of function).",{
 	expect_equivalent(
 		logLogisticRegression(seq(-10,10,0.1), .Hill(seq(-10,10,0.1), c(1,0,0))
 			, conc_as_log=TRUE, viability_as_pct = FALSE), list(1,0,0))
+
 	expect_equivalent(
 		logLogisticRegression(seq(-10,10,0.1), .Hill(seq(-10,10,0.1), c(1,0,0))
 			, conc_as_log=TRUE, viability_as_pct = FALSE, family="Cauchy"), list(1,0,0))
-	expect_equal(logLogisticRegression(c(1, 2, 3), c(50, 60, 70)), list(HS = 1.22388251239748, E_inf = 59.9999882231278, EC50 = 1e-06), tolerance=1e-3) #should run with no objections
-    expect_equal(logLogisticRegression(c(1, 2, 3), c(50, 60, 70), family="Cauchy"), list(HS = 1.08959673823682, E_inf = 60.0004126580051, EC50 = 3.39074306428225e-06), tolerance=1e-3) #should run with no objections
-	expect_equal(logLogisticRegression(c(1, 2, 3), c(50, 60, 70), trunc=FALSE), list(HS = 1.22388251239748, E_inf = 59.9999882231278, EC50 = 1e-06), tolerance=1e-3) #should run with no objections
-    expect_equal(logLogisticRegression(c(1, 2, 3), c(50, 60, 70), family="Cauchy", trunc=FALSE), list(HS = 1.08959673823682, E_inf = 60.0004126580051, EC50 = 3.39074306428225e-06), tolerance=1e-3) #should run with no objections
+
+	expect_equal(logLogisticRegression(c(1, 2, 3), c(70, 60, 50)), 
+        structure(list(HS = 0.766235008089789, E_inf = 0, EC50 = 3.14114781624406), Rsquare = 0.983872720888105), 
+        tolerance=1e-3) #should run with no objections
+
+    expect_equal(logLogisticRegression(c(1, 2, 3), c(70, 60, 50), family="Cauchy"), 
+        structure(list(HS = 0.766099642757164, E_inf = 0, EC50 = 3.13883130512133), Rsquare = 0.983863295704847), 
+        tolerance=1e-3) #should run with no objections
+
+	expect_equal(logLogisticRegression(c(1, 2, 3), c(70, 60, 50), trunc=FALSE), 
+        structure(list(HS = 0.766234869170442, E_inf = 0, EC50 = 3.14114817741207), Rsquare = 0.983872721139933), 
+        tolerance=1e-3) #should run with no objections
+
+    expect_equal(logLogisticRegression(c(1, 2, 3), c(70, 60, 50), family="Cauchy", trunc=FALSE), 
+        structure(list(HS = 0.766099642757164, E_inf = 0, EC50 = 3.13883130512133), Rsquare = 0.983863295704847),
+        tolerance=1e-3) #should run with no objections
+
+    ## These next few tests make sure trunc is doing something sensible
+    expect_equal(logLogisticRegression(c(0.1, 1, 2, 3), c(110, 70, 60, 50), family="Cauchy", trunc=FALSE), 
+        structure(list(HS = 1.83941027802297, E_inf = 46.2252841409534, EC50 = 0.929240163785174), Rsquare = 0.950154102951421),
+        tolerance=1e-3) #should run with no objections
+    
+    expect_equal(logLogisticRegression(c(0.1, 1, 2, 3), c(110, 70, 60, 50), family="Cauchy", trunc=TRUE), 
+        structure(list(HS = 2.06741101065827, E_inf = 48.0764684303728, EC50 = 0.900808050726654), Rsquare = 0.986745954925997),
+        tolerance=1e-3) #should run with no objections
+
+    expect_equivalent(logLogisticRegression(c(0.1, 1, 2, 3), c(100, 70, 60, 50), trunc=TRUE), 
+        logLogisticRegression(c(0.1, 1, 2, 3), c(500, 70, 60, 50), trunc=TRUE))
+
 })


### PR DESCRIPTION
I tested this on my machine, but I don't trust that on its own. 

The changes to tests are mostly to accommodate different error messages (they are now generic across packages). However, some changes were also made to use more reasonable values to test loglogisticregression (previously, the curve was going the wrong way!). I tested against the old implementation and they return very similar, if not exactly the same results, on the test cases. The difference is mainly caused by decrease in a tolerance parameter in optimization, which for very noisy curves prevents the algorithm from stopping. It now tends to drift towards the endpoints of the interval when fitting a constant curve, which is different, but does make it easier to catch degenerate cases. 