### PR TITLE
increasing the default precision so that the pattern search tends to …

### DIFF
--- a/R/LogLogisticRegression.R
+++ b/R/LogLogisticRegression.R
@@ -53,9 +53,9 @@
 #' @importFrom stats optim dcauchy dnorm pcauchy rcauchy rnorm pnorm integrate
 logLogisticRegression <- function(conc,
                                   viability,
-                                  density = c(2, 10, 2),
+                                  density = c(2, 10, 5),
                                   step = .5 / density,
-                                  precision = 0.05,
+                                  precision = 1e-4,
                                   lower_bounds = c(0, 0, -6),
                                   upper_bounds = c(4, 1, 6),
                                   scale = 0.07,


### PR DESCRIPTION
…fall within 1e-3 of the optim results (optim convergence seems to be platform dependent). 

The fact that optim convergence on some platforms and doesn't on others with the same data is unsettling, but now pattern search gives out results that match to within 1e-3. There could be an argument made for greater tolerance for errors, but on the log 10 scale 0.01 can actually be meaningful. 