### PR TITLE
fixing a typo

### DIFF
--- a/R/PharmacoSet-class.R
+++ b/R/PharmacoSet-class.R
@@ -125,7 +125,7 @@ PharmacoSet <-  function(name, molecularProfiles=list(), sample=data.frame(),
 
     pSet  <- .PharmacoSet(
         annotation=cSet@annotation,
-        molecularProfiles=cSet@olecularProfiles,
+        molecularProfiles=cSet@molecularProfiles,
         sample=cSet@sample,
         treatment=cSet@treatment,
         datasetType=cSet@datasetTypes,


### PR DESCRIPTION
Hi

while creating a new PharmacoSet based on the vignette, I got the error: 
```
PharmacoGx::PharmacoSet(
    name="alabama",
    molecularProfiles = list(),
    sample = data.frame(),
    treatment = data.frame(),
    sensitivityInfo = data.frame(),
    sensitivityRaw = array(dim = c(0, 0, 0)),
    sensitivityProfiles = matrix(),
    sensitivityN = matrix(nrow = 0, ncol = 0),
    perturbationN = array(NA, dim = c(0, 0, 0)),
    curationTreatment = data.frame(),
    curationSample = data.frame(),
    curationTissue = data.frame(),
    datasetType = c("perturbation"),
    verify = TRUE
)
```

```
Error in initialize(value, ...) : 
  no slot of name "olecularProfiles" for this object of class "CoreSet"
```

traceback revealed this typo in the code. 
best
Attila 