### PR TITLE
PharmacoSet constructor typos

### DIFF
--- a/R/PharmacoSet-class.R
+++ b/R/PharmacoSet-class.R
@@ -128,7 +128,7 @@ PharmacoSet <-  function(name, molecularProfiles=list(), sample=data.frame(),
         molecularProfiles=cSet@molecularProfiles,
         sample=cSet@sample,
         treatment=cSet@treatment,
-        datasetType=cSet@datasetTypes,
+        datasetType=cSet@datasetType,
         treatmentResponse=cSet@treatmentResponse,
         perturbation=cSet@perturbation,
         curation=cSet@curation

--- a/R/PharmacoSet-class.R
+++ b/R/PharmacoSet-class.R
@@ -125,7 +125,7 @@ PharmacoSet <-  function(name, molecularProfiles=list(), sample=data.frame(),
 
     pSet  <- .PharmacoSet(
         annotation=cSet@annotation,
-        molecularProfiles=cSet@olecularProfiles,
+        molecularProfiles=cSet@molecularProfiles,
         sample=cSet@sample,
         treatment=cSet@treatment,
         datasetType=cSet@datasetTypes,

--- a/R/PharmacoSet-class.R
+++ b/R/PharmacoSet-class.R
@@ -108,6 +108,7 @@ PharmacoSet <-  function(name, molecularProfiles=list(), sample=data.frame(),
 
     cSet <- CoreGx::CoreSet(
         name=name,
+        molecularProfiles = molecularProfiles,
         sample=sample,
         treatment=treatment,
         sensitivityInfo=sensitivityInfo,


### PR DESCRIPTION
Hi ,

I found 2 typos in the function which lead to errors. 

Also the `molecularProfile` is not used for making the `cSet`, but then `cSet@molecularProfiles` is used to construct the `pSet`. I guess it was missing, but not sure about it. 
cheers,
Attila